### PR TITLE
Add support for restoring 'erlang-shell-mode' buffers

### DIFF
--- a/src/workgroups-specialbufs.el
+++ b/src/workgroups-specialbufs.el
@@ -349,6 +349,11 @@ You can get these commands using `wg-get-org-agenda-view-commands'."
                                 (wg-dbind (url) vars
                                   (w3m-goto-url url))))))
 
+;; Erlang shell
+(wg-support 'erlang-shell-mode 'erlang
+            `((deserialize . ,(lambda (buffer vars)
+                                (erlang-shell)))))
+
 
 ;; Wanderlust modes:
 ;; WL - folders


### PR DESCRIPTION
Hi, thanks for your work on workgroups. This enables very simple restoring of erlang-shell-mode buffers
