### PR TITLE
Set default workgroup from current-wg to previous-wg

### DIFF
--- a/src/workgroups2.el
+++ b/src/workgroups2.el
@@ -3477,7 +3477,7 @@ Or scream unless NOERROR."
   "Read a workgroup name from `wg-workgroup-names'.
 REQUIRE-MATCH to match."
   (wg-completing-read "Workgroup: " (wg-workgroup-names) nil require-match nil nil
-                      (awhen (wg-current-workgroup t) (wg-workgroup-name it))))
+                      (awhen (wg-previous-workgroup t) (wg-workgroup-name it))))
 
 (defun wg-new-default-workgroup-name ()
   "Return a new, unique, default workgroup name."


### PR DESCRIPTION
Don't know much about why the `current-workgroup` is the default value when switching workgroup. I'd like to have the previous workgroup as the default value so that I can switch it back and forth very easily. (Yes I knew there's a swap-workgroup function but I'd like to keep using the same switch function for switching)

Don't know if I need to bring an option for this behaviour, pls review and any ideas are welcome. 
