### PR TITLE
Support dired-sidebar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,14 +19,17 @@ clean:
 .PHONY: deps
 deps:
 	mkdir -p deps;
-	if [ ! -f deps/f.el ];               then curl https://raw.githubusercontent.com/rejeep/f.el/master/f.el -o deps/f.el; fi;
-	if [ ! -f deps/s.el ];               then curl https://raw.githubusercontent.com/magnars/s.el/master/s.el -o deps/s.el; fi;
-	if [ ! -f deps/dash.el ];            then curl https://raw.githubusercontent.com/magnars/dash.el/master/dash.el -o deps/dash.el; fi;
-	if [ ! -f deps/anaphora.el ];        then curl https://raw.githubusercontent.com/rolandwalker/anaphora/master/anaphora.el -o deps/anaphora.el; fi;
-	if [ ! -f deps/magit.el ];           then curl https://raw.githubusercontent.com/magit/magit/master/magit.el -o deps/magit.el; fi;
-	if [ ! -f deps/git-commit-mode.el ]; then curl https://raw.githubusercontent.com/magit/git-modes/master/git-commit-mode.el -o deps/git-commit-mode.el; fi;
-	if [ ! -f deps/git-rebase-mode.el ]; then curl https://raw.githubusercontent.com/magit/git-modes/master/git-rebase-mode.el -o deps/git-rebase-mode.el; fi;
-	if [ ! -f deps/magit-key-mode.el ];  then curl https://raw.githubusercontent.com/magit/magit/master/magit-key-mode.el -o deps/magit-key-mode.el; fi;
+	if [ ! -f deps/f.el ];                 then curl https://raw.githubusercontent.com/rejeep/f.el/master/f.el -o deps/f.el; fi;
+	if [ ! -f deps/s.el ];                 then curl https://raw.githubusercontent.com/magnars/s.el/master/s.el -o deps/s.el; fi;
+	if [ ! -f deps/dash.el ];              then curl https://raw.githubusercontent.com/magnars/dash.el/master/dash.el -o deps/dash.el; fi;
+	if [ ! -f deps/anaphora.el ];          then curl https://raw.githubusercontent.com/rolandwalker/anaphora/master/anaphora.el -o deps/anaphora.el; fi;
+	if [ ! -f deps/magit.el ];             then curl https://raw.githubusercontent.com/magit/magit/master/magit.el -o deps/magit.el; fi;
+	if [ ! -f deps/git-commit-mode.el ];   then curl https://raw.githubusercontent.com/magit/git-modes/master/git-commit-mode.el -o deps/git-commit-mode.el; fi;
+	if [ ! -f deps/git-rebase-mode.el ];   then curl https://raw.githubusercontent.com/magit/git-modes/master/git-rebase-mode.el -o deps/git-rebase-mode.el; fi;
+	if [ ! -f deps/magit-key-mode.el ];    then curl https://raw.githubusercontent.com/magit/magit/master/magit-key-mode.el -o deps/magit-key-mode.el; fi;
+	if [ ! -f deps/dired-sidebar.el ];     then curl https://raw.githubusercontent.com/jojojames/dired-sidebar/master/dired-sidebar.el -o deps/dired-sidebar.el; fi;
+	if [ ! -f deps/dired-subtree.el ];     then curl https://raw.githubusercontent.com/Fuco1/dired-hacks/master/dired-subtree.el -o deps/dired-subtree.el; fi;
+	if [ ! -f deps/dired-hacks-utils.el ]; then curl https://raw.githubusercontent.com/Fuco1/dired-hacks/master/dired-hacks-utils.el -o deps/dired-hacks-utils.el; fi;
 
 
 docs:

--- a/src/workgroups2.el
+++ b/src/workgroups2.el
@@ -1948,8 +1948,11 @@ as Workgroups' command remappings."
       (set-window-prev-buffers
        selwin (wg-unpickel (wg-win-parameter win 'prev-buffers)))
       (set-window-next-buffers
-       selwin (wg-unpickel (wg-win-parameter win 'next-buffers)))
-      )))
+       selwin (wg-unpickel (wg-win-parameter win 'next-buffers))))
+    (dolist (param '(window-side window-slot))
+      (let ((value (wg-win-parameter win param)))
+        (when value
+          (set-window-parameter selwin param value))))))
 
 
 (defun wg-window-point (ewin)
@@ -1999,7 +2002,11 @@ Return value."
           (wg-set-win-parameter
            win 'next-buffers (wg-pickel (remove nil (cl-subseq (window-next-buffers window) 0 4))))
           (wg-set-win-parameter
-           win 'prev-buffers (wg-pickel (remove nil (cl-subseq (window-prev-buffers window) 0 4)))))))
+           win 'prev-buffers (wg-pickel (remove nil (cl-subseq (window-prev-buffers window) 0 4)))))
+        (dolist (param '(window-side window-slot))
+          (let ((value (window-parameter window param)))
+            (when value
+              (wg-set-win-parameter win param value))))))
     win))
 
 (defun wg-toggle-window-dedicated-p ()

--- a/src/workgroups2.el
+++ b/src/workgroups2.el
@@ -1,5 +1,4 @@
-;;; workgroups2.el --- New workspaces for Emacs
-;;; -*- coding: utf-8; lexical-binding: t -*-
+;;; workgroups2.el --- New workspaces for Emacs -*- coding: utf-8; lexical-binding: t -*-
 ;;
 ;; Copyright (C) 2013-2014 Sergey Pashinin
 ;; Copyright (C) 2010-2011 tlh

--- a/tests/workgroups2-tests.el
+++ b/tests/workgroups2-tests.el
@@ -153,6 +153,36 @@
   ;; TODO: handle errors
   )
 
+(ert-deftest 305-dired-sidebar ()
+  (let ((wg-log-level 0)
+        message-log-max)
+    ;; prepare
+    (delete-other-windows)
+    (switch-to-buffer wg-default-buffer)
+
+    ;; create sidebar window
+    (require 'dired-sidebar)
+    (dired-sidebar-toggle-sidebar "/tmp")
+    (dired-sidebar-jump-to-sidebar)
+    (should (eq major-mode 'dired-sidebar-mode))
+    (should (window-parameter (selected-window) 'window-side))
+    (should (window-parameter (selected-window) 'window-slot))
+    (wg-save-session)
+
+    ;; save and restore
+    (workgroups-mode 0)
+    (switch-to-buffer wg-default-buffer)
+    (delete-other-windows)
+    (workgroups-mode 1)
+    (switch-to-buffer wg-default-buffer)
+    (should (not (window-parameter (selected-window) 'window-side)))
+    (should (not (window-parameter (selected-window) 'window-slot)))
+    (should (dired-sidebar-showing-sidebar-p))
+    (dired-sidebar-jump-to-sidebar)
+    (should (eq major-mode 'dired-sidebar-mode))
+    (should (window-parameter (selected-window) 'window-side))
+    (should (window-parameter (selected-window) 'window-slot))))
+
 (ert-deftest 310-frames ()
   ;; Create some frames
   (should wg-control-frames)


### PR DESCRIPTION
This PR adds support for saving and restoring [dired-sidebar](https://github.com/jojojames/dired-sidebar) windows, as well as side windows generally.

Changes:
* Dired-sidebar uses [side windows](https://www.gnu.org/software/emacs/manual/html_node/elisp/Side-Windows.html#Side-Windows), so the save/load code now includes the `window-side` and `window-slot` window parameters to preserve side window status. Without this change, side windows would be restored as ordinary windows, which breaks some behavior.
* The window restoration process for dired-sidebar windows actually replaces the restored window with a fresh window created by dired-sidebar. This is done in order to avoid duplicating the implementation details of dired-sidebar's window setup in the serialization/deserialization code.
* Lexical binding in workgroups2.el was broken and has been fixed.

Testing:
* Manually verified that dired-sidebar windows are saved and restored and that they keep their status as side windows.
* Added an automated test for above.
* Manually tested that a couple other modes' windows (dired, magit) are saved and restored
* Successfully ran the automated test suite with `make deps && make testgui` (I had to comment out the Magit test and `310-frames`, which are broken on master)
* I have not tested with other packages that use side windows.