### PR TITLE
fix: define-obsolete-variable-alias require "when" argument in emacs28

### DIFF
--- a/src/workgroups2.el
+++ b/src/workgroups2.el
@@ -238,7 +238,7 @@ and inactive mode-lines, so this feature defaults to off."
   "Hook run by `wg-switch-to-workgroup'."
   :type 'hook
   :group 'workgroups)
-(define-obsolete-variable-alias 'wg-switch-to-workgroup-hook 'wg-after-switch-to-workgroup-hook)
+(define-obsolete-variable-alias 'wg-switch-to-workgroup-hook 'wg-after-switch-to-workgroup-hook "20140830")
 
 (defcustom wg-pre-window-configuration-change-hook nil
   "Hook run before any function that triggers `window-configuration-change-hook'."


### PR DESCRIPTION
The 'when' argument of make-obsolete and related functions is
mandatory since https://emba.gnu.org/emacs/emacs/-/commit/32c6732d16385f242b1109517f25e9aefd6caa5c

    The use of those functions without a 'when' argument was marked
    obsolete back in Emacs-23.1. The affected functions are:
    make-obsolete, define-obsolete-function-alias, make-obsolete-variable,
    define-obsolete-variable-alias.

See https://github.com/manateelazycat/emacs-application-framework/pull/509